### PR TITLE
Update the download url for sle12sp3 box

### DIFF
--- a/boxes/sle12-sp3.x86_64-0.0.1.libvirt.json
+++ b/boxes/sle12-sp3.x86_64-0.0.1.libvirt.json
@@ -6,7 +6,7 @@
          "providers" : [
             {
                "name" : "libvirt",
-               "url" : "http://download.suse.de/ibs/Devel:/Storage:/5.0/vagrant/sle12-sp3.x86_64.libvirt.box"
+               "url" : "http://download.suse.de/ibs/Devel:/Storage:/5.0/vagrant/sle12sp3.x86_64.box"
             }
          ],
          "version" : "0.0.1"


### PR DESCRIPTION
The command to add the box sle12-sp3.x86_64-0.0.1.libvirt.json  fails because the download URL is invalid. The HTTP status code returned is 404. This commit updates the URL with a URI to a box file in the same directory of the previous URI.